### PR TITLE
fix: extract enum default .value before storing in AST constant node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 
+## v0.9.1 - 2026-03-12
+- Fixed enum member defaults by extracting `.value` before storing in the AST constant node
+- Added tests for enum member as default value for `OptDef` and `ArgDef`
+- Added tests for `include_context` parameter in `build_command`
+- Added tests for `exception_type` and `exception_pattern` parameters in `get_output` helper
+
+
 ## v0.9.0 - 2026-02-11
 - Switched build backend from hatchling to uv_build
 - Replaced mypy and basedpyright with ty for type checking

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "typer-repyt"
-version = "0.9.0"
+version = "0.9.1"
 description = "Build Typer commands dynamically"
 authors = [
     {name = "Tucker Beck", email ="tucker.beck@gmail.com"},

--- a/src/typer_repyt/build_command.py
+++ b/src/typer_repyt/build_command.py
@@ -1,4 +1,5 @@
 import ast
+import enum
 from functools import update_wrapper
 import inspect
 import textwrap
@@ -259,7 +260,11 @@ def build_command(
             args.append(arg)
         else:
             kwonlyargs.append(arg)
-            kw_defaults.append(ast.Constant(value=param_def.default))
+            kw_defaults.append(
+                ast.Constant(
+                    value=param_def.default.value if isinstance(param_def.default, enum.Enum) else param_def.default
+                )
+            )
 
     # Extract the function body from the template function
     source = textwrap.dedent(inspect.getsource(func)).strip()

--- a/tests/test_build_command.py
+++ b/tests/test_build_command.py
@@ -11,7 +11,7 @@ import typer
 from typer_repyt.build_command import build_command, OptDef, ArgDef, ParamDef, DecDef
 from typer_repyt.exceptions import BuildCommandError, RepytError
 
-from tests.helpers import check_output, check_help, match_output, match_help
+from tests.helpers import check_output, check_help, get_output, match_output, match_help
 
 
 def simple_decorator(func: Callable[..., Any]) -> Callable[..., Any]:
@@ -365,7 +365,7 @@ def test_build_command__option__parser():
         cli,
         """--dyna={"c4": "boom", "semtex": 13}""",
         """--mite={"blast_cord": true, "fuse": true}""",
-        expected_substring=["dyna=Dyna(c4='boom', semtex=13) mite=Mite(blast_cord=True, fuse=True)"]
+        expected_substring=["dyna=Dyna(c4='boom', semtex=13) mite=Mite(blast_cord=True, fuse=True)"],
     )
 
 
@@ -675,3 +675,159 @@ def test_build_command__with_enum_param_type():
             "dyna=jawa",
         ],
     )
+
+
+def test_build_command__option__enum_default():
+    cli = typer.Typer()
+
+    class DynaChoice(StrEnum):
+        jawa = auto()
+        ewok = auto()
+
+    def dynamic(dyna: DynaChoice):
+        print(f"dyna={dyna.value}")
+
+    build_command(
+        cli,
+        dynamic,
+        OptDef(name="dyna", param_type=DynaChoice, default=DynaChoice.jawa),
+    )
+
+    # Invoke with no arguments — default should kick in
+    check_output(cli, expected_substring="dyna=jawa")
+    # Explicitly overriding the default should also work
+    check_output(cli, "--dyna=ewok", expected_substring="dyna=ewok")
+
+
+def test_build_command__argument__enum_default():
+    cli = typer.Typer()
+
+    class MiteChoice(StrEnum):
+        blast_cord = auto()
+        fuse = auto()
+
+    def dynamic(mite: MiteChoice):
+        print(f"mite={mite.value}")
+
+    build_command(
+        cli,
+        dynamic,
+        ArgDef(name="mite", param_type=MiteChoice, default=MiteChoice.blast_cord),
+    )
+
+    # Invoke with no arguments — default should kick in
+    check_output(cli, expected_substring="mite=blast_cord")
+    # Explicitly passing a value should override the default
+    check_output(cli, "fuse", expected_substring="mite=fuse")
+
+
+def test_build_command__include_context__default_name():
+    cli = typer.Typer()
+
+    def dynamic(dyna: str):
+        print(f"{dyna=}")
+
+    build_command(
+        cli,
+        dynamic,
+        OptDef(name="dyna", param_type=str),
+        include_context=True,
+    )
+
+    check_output(cli, "--dyna=ZOOM", expected_substring="dyna='ZOOM'")
+
+
+def test_build_command__include_context__custom_name():
+    cli = typer.Typer()
+
+    def dynamic(dyna: str):
+        print(f"{dyna=}")
+
+    build_command(
+        cli,
+        dynamic,
+        OptDef(name="dyna", param_type=str),
+        include_context="t_ctx",
+    )
+
+    check_output(cli, "--dyna=ZOOM", expected_substring="dyna='ZOOM'")
+
+
+def test_build_command__include_context__context_is_accessible():
+    cli = typer.Typer()
+
+    def dynamic(dyna: str):
+        print(f"{dyna=}")
+
+    build_command(
+        cli,
+        dynamic,
+        OptDef(name="dyna", param_type=str),
+        include_context=True,
+    )
+
+    # The command should invoke successfully; context presence is validated internally by typer
+    check_output(cli, "--dyna=ZOOM", expected_substring="dyna='ZOOM'")
+
+
+def test_get_output__exception_type__matches():
+    cli = typer.Typer()
+
+    def dynamic(dyna: str):
+        raise ValueError("intentional error")
+
+    build_command(
+        cli,
+        dynamic,
+        OptDef(name="dyna", param_type=str),
+    )
+
+    # Should not raise an AssertionError since the exception type matches
+    get_output(cli, "--dyna=ZOOM", exit_code=1, exception_type=ValueError)
+
+
+def test_get_output__exception_type__mismatch_fails():
+    cli = typer.Typer()
+
+    def dynamic(dyna: str):
+        raise ValueError("intentional error")
+
+    build_command(
+        cli,
+        dynamic,
+        OptDef(name="dyna", param_type=str),
+    )
+
+    with pytest.raises(AssertionError, match="Expected exception type doesn't match"):
+        get_output(cli, "--dyna=ZOOM", exit_code=1, exception_type=RuntimeError)
+
+
+def test_get_output__exception_pattern__matches():
+    cli = typer.Typer()
+
+    def dynamic(dyna: str):
+        raise ValueError("intentional error")
+
+    build_command(
+        cli,
+        dynamic,
+        OptDef(name="dyna", param_type=str),
+    )
+
+    get_output(cli, "--dyna=ZOOM", exit_code=1, exception_pattern="intentional")
+
+
+def test_get_output__exception_pattern__mismatch_fails():
+    cli = typer.Typer()
+
+    def dynamic(dyna: str):
+        raise ValueError("intentional error")
+
+    build_command(
+        cli,
+        dynamic,
+        OptDef(name="dyna", param_type=str),
+    )
+
+    with pytest.raises(AssertionError, match="Expected exception text doesn't match pattern"):
+        get_output(cli, "--dyna=ZOOM", exit_code=1, exception_pattern="something_else_entirely")


### PR DESCRIPTION
Fixed a bug where passing an enum member as a default to OptDef or ArgDef would fail at compile time because ast.Constant cannot hold an enum object — now extracts .value via isinstance(param_def.default, enum. Enum) check

Also added some unit tests for this scenario and others to increase coverage.